### PR TITLE
Make Testing this a bit easier

### DIFF
--- a/compose/test.yml
+++ b/compose/test.yml
@@ -5,37 +5,43 @@ services:
     environment:
       DEBUG: '*'
       channel__host: 'node-1'
-      nats__hosts: 'nats:4222'
+      nats__hosts: 'nats-a:4222,nats-b:4222,nats-c:4222'
       seeds: 'node-1:3455,node-2:3456'
     networks:
       - skyring 
     depends_on:
-      - nats
+      - nats-a
+      - nats-b
+      - nats-c
 
   node-2:
     build: ../
     environment:
       DEBUG: '*'
       seeds: 'node-1:3455,node-2:3456'
-      nats__hosts: 'nats:4222'
+      nats__hosts: 'nats-a:4222,nats-b:4222,nats-c:4222'
       channel__host: 'node-2'
       channel__port: 3456
     networks:
       - skyring
     depends_on:
-      - nats
+      - nats-a
+      - nats-b
+      - nats-c
 
   node-3:
     build: ../
     environment:
       DEBUG: '*'
       seeds: 'node-1:3455,node-2:3456'
-      nats__hosts: 'nats:4222'
+      nats__hosts: 'nats-a:4222,nats-b:4222,nats-c:4222'
       channel__host: 'node-3'
     networks:
       - skyring
     depends_on:
-      - nats
+      - nats-a
+      - nats-b
+      - nats-c
       - node-1
       - node-2
 
@@ -44,12 +50,14 @@ services:
     environment:
       DEBUG: '*'
       seeds: 'node-1:3455,node-2:3456'
-      nats__hosts: 'nats:4222'
+      nats__hosts: 'nats-a:4222,nats-b:4222,nats-c:4222'
       channel__host: 'node-4'
     networks:
       - skyring
     depends_on:
-      - nats
+      - nats-a
+      - nats-b
+      - nats-c
       - node-1
       - node-2
 
@@ -59,12 +67,14 @@ services:
     environment:
       DEBUG: '*'
       seeds: 'node-1:3455,node-2:3456'
-      nats__hosts: 'nats:4222'
+      nats__hosts: 'nats-a:4222,nats-b:4222,nats-c:4222'
       channel__host: 'node-5'
     networks:
       - skyring
     depends_on:
-      - nats
+      - nats-a
+      - nats-b
+      - nats-c
       - node-1
       - node-2
       - node-3
@@ -72,8 +82,32 @@ services:
     command: >
       npm test
 
-  nats:
+  nats-a:
     image: nats:latest
+    volumes:
+      - ./etc/nats:/tmp
+    command: >
+      -c /tmp/a.conf -D
+    networks:
+      - skyring
+  nats-b:
+    image: nats:latest
+    volumes:
+      - ./etc/nats:/tmp
+    command: >
+      -c /tmp/b.conf -D
+    depends_on:
+      - nats-a
+    networks:
+      - skyring
+  nats-c:
+    image: nats:latest
+    volumes:
+      - ./etc/nats:/tmp
+    depends_on:
+      - nats-a
+    command: >
+      -c /tmp/c.conf -D
     networks:
       - skyring
 

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -55,8 +55,9 @@ services:
 
   node-5:
     build: ../
+    hostname: node-5
     environment:
-      DEBUG: 'skyring:*'
+      DEBUG: '*'
       seeds: 'node-1:3455,node-2:3456'
       nats__hosts: 'nats:4222'
       channel__host: 'node-5'

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -56,6 +56,7 @@ services:
   node-5:
     build: ../
     environment:
+      DEBUG: 'skyring:*'
       seeds: 'node-1:3455,node-2:3456'
       nats__hosts: 'nats:4222'
       channel__host: 'node-5'

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -3,7 +3,6 @@ services:
   node-1:
     build: ../
     environment:
-      DEBUG: '*'
       channel__host: 'node-1'
       nats__hosts: 'nats-a:4222,nats-b:4222,nats-c:4222'
       seeds: 'node-1:3455,node-2:3456'
@@ -17,7 +16,6 @@ services:
   node-2:
     build: ../
     environment:
-      DEBUG: '*'
       seeds: 'node-1:3455,node-2:3456'
       nats__hosts: 'nats-a:4222,nats-b:4222,nats-c:4222'
       channel__host: 'node-2'
@@ -32,7 +30,6 @@ services:
   node-3:
     build: ../
     environment:
-      DEBUG: '*'
       seeds: 'node-1:3455,node-2:3456'
       nats__hosts: 'nats-a:4222,nats-b:4222,nats-c:4222'
       channel__host: 'node-3'
@@ -48,7 +45,6 @@ services:
   node-4:
     build: ../
     environment:
-      DEBUG: '*'
       seeds: 'node-1:3455,node-2:3456'
       nats__hosts: 'nats-a:4222,nats-b:4222,nats-c:4222'
       channel__host: 'node-4'
@@ -65,7 +61,6 @@ services:
     build: ../
     hostname: node-5
     environment:
-      DEBUG: '*'
       seeds: 'node-1:3455,node-2:3456'
       nats__hosts: 'nats-a:4222,nats-b:4222,nats-c:4222'
       channel__host: 'node-5'

--- a/lib/server/api/post_timer.js
+++ b/lib/server/api/post_timer.js
@@ -1,17 +1,21 @@
 'use strict';
+const validate = require('./validators/timer');
 
 module.exports = {
   path: '/timer'
 , method: 'POST'
 , middleware: [require('./middleware/proxy')]
 , handler: (req, res, node, cb) => {
-    const id = req.$.headers['x-timer-id'];
-    req.$.timers.create(id, req.$.body, (err) => {
-      if (err) return cb(err);
-      res.$.set('location', `/timer/${id}`);
-      res.$.status(201);
-      cb();
-    });
+    validate(req.$.body, (er, data) => {
+      if (er) return cb(er);
+      const id = req.$.headers['x-timer-id'];
+      req.$.timers.create(id, data, (err) => {
+        if (err) return cb(err);
+        res.$.set('location', `/timer/${id}`);
+        res.$.status(201);
+        cb();
+      });
+    })
   }
 }
 

--- a/lib/server/api/post_timer.js
+++ b/lib/server/api/post_timer.js
@@ -1,12 +1,12 @@
 'use strict';
-const timer = require('../../timer');
+
 module.exports = {
   path: '/timer'
 , method: 'POST'
 , middleware: [require('./middleware/proxy')]
 , handler: (req, res, node, cb) => {
     const id = req.$.headers['x-timer-id'];
-    timer.create(id, req.$.body, (err) => {
+    req.$.timers.create(id, req.$.body, (err) => {
       if (err) return cb(err);
       res.$.set('location', `/timer/${id}`);
       res.$.status(201);

--- a/lib/server/api/validators/timer.js
+++ b/lib/server/api/validators/timer.js
@@ -1,0 +1,54 @@
+'use strict'
+const type_exp = /^\[object (.*)\]$/
+function typeOf(obj) {
+  if (obj === null) return 'Null';
+  if (obj === undefined) return 'Undefined';
+  return type_exp.exec( Object.prototype.toString.call(obj) )[1];
+}
+
+module.exports = function(data, cb) {
+  debugger;
+  if( isNaN(data.timeout) || data.timeout < 1 ) {
+    const err = new TypeError('timeout is required and must be a positive number')
+    err.statusCode = 400
+    return setImmediate(cb, err)
+  }
+  if(data.data) {
+    const type = typeOf(data.data);
+    switch(type){
+        case 'String':
+        case 'Object':
+          return setImmediate(cb, null, data)
+        default:
+          const err = new TypeError('data is required and must be a string or object');
+          err.statusCode = 400;
+          console.log(cb)
+          return setImmediate(cb, err);
+    }
+  }
+
+  if (typeOf(data.callback) !== 'Object') {
+    const err = new TypeError('callback is required and must be an object');
+    err.statusCode = 400;
+    return setImmediate(cb, err);
+  }
+
+  if (typeOf(data.callback.transport) !== 'String') {
+    const err = new TypeError('callback.transport is required and must be a string');
+    err.statusCode = 400;
+    return setImmediate(cb, err);
+  }
+
+  if (typeOf(data.callback.uri) !== 'String') {
+    const err = new TypeError('callback.uri is required and must be a string');
+    err.statusCode = 400;
+    return setImmediate(cb, err);
+  }
+
+  if (typeOf(data.callback.method) !== 'String') {
+    const err = new TypeError('callback.method is required and must be a string');
+    err.statusCode = 400;
+    return setImmediate(cb, err);
+  }
+  setImmediate(cb, null, data);
+}

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -37,8 +37,24 @@ class Server extends http.Server {
     super((req, res) => {
       this._router.handle(req, res)
     });
+    this.closed = false;
+    this.options = Object.assign({}, {
+      seeds: null
+    }, opts)
     this.loaded = false;
-    this._node = opts.node || new Node();
+    if( opts.node ){
+      this._node = opts.node instanceof Node 
+        ? opts.node 
+        : new Node(
+            opts.node.host,
+            opts.node.port,
+            opts.node.name,
+            opts.node.app
+          );
+    } else {
+      this._node = new Node() 
+    }
+    
     this._router = new Router(this._node);
     this._node.on('ringchange', (evt) => {
       timer.rebalance(evt, this._node, (data) => {
@@ -81,7 +97,8 @@ class Server extends http.Server {
    * @return {module:skyring/lib/server}
    **/
   listen(port, host, backlog, callback) {
-    this._node.join(null, (err) => {
+    debug('seed nodes', this.options.seeds);
+    this._node.join(this.options.seeds, (err) => {
       if (err) return callback(err)
       this._node.handle(( req, res ) => {
         this._router.handle( req, res );
@@ -106,7 +123,6 @@ class Server extends http.Server {
     }
     const res = new mock.Response();
     const req = new mock.Request( opts );
-
     this._router.handle( req, res );
   }
   /**
@@ -116,11 +132,12 @@ class Server extends http.Server {
    * @param {Function} callback A callback to be called when the server is completely shut down
    **/
   close( cb ){
-
+    if(this.closed) return cb && setImmediate(cb);
     super.close(()=>{
       this._node.close(() => {
         timer.shutdown(() => {
           debug('closing server')
+          this.closed = true
           cb && cb()
         })
       })

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -18,12 +18,11 @@ const http   = require('http')
     , mock   = require('./mock')
     , Node   = require('./node')
     , Router = exports.Router = require('./router')
-    , timer  = require('../timer')
+    , Timer  = require('../timer')
     , debug  = Debug('skyring:server')
     ;
 
 /**
- * Description
  * @constructor
  * @extends http.Server
  * @alias module:skyring/lib/server
@@ -40,6 +39,7 @@ class Server extends http.Server {
     this.closed = false;
     this.options = Object.assign({}, {
       seeds: null
+    , nats: null
     }, opts)
     this.loaded = false;
     if( opts.node ){
@@ -54,10 +54,11 @@ class Server extends http.Server {
     } else {
       this._node = new Node() 
     }
-    
-    this._router = new Router(this._node);
+    this._group = this._node.name
+    this._timers = new Timer(this.options.nats);
+    this._router = new Router(this._node, this._timers);
     this._node.on('ringchange', (evt) => {
-      timer.rebalance(evt, this._node, (data) => {
+      this._timers.rebalance(evt, this._node, (data) => {
         this.proxy(data);
       });
     });
@@ -70,7 +71,6 @@ class Server extends http.Server {
    **/
   load() {
     if( this.loaded ) return this;
-
     const routes = require('./api')
     Object.keys(routes)
           .forEach((name) => {
@@ -99,11 +99,14 @@ class Server extends http.Server {
   listen(port, host, backlog, callback) {
     debug('seed nodes', this.options.seeds);
     this._node.join(this.options.seeds, (err) => {
-      if (err) return callback(err)
+      if (err) {
+        console.error(err)
+        return callback && callback(err)
+      }
       this._node.handle(( req, res ) => {
         this._router.handle( req, res );
       })
-      timer.watch('skyring', (err, data) => {
+      this._timers.watch(`skyring:${this._group}`, (err, data) => {
         this.proxy(data)
       });
       super.listen(port, host, backlog, callback)
@@ -135,7 +138,7 @@ class Server extends http.Server {
     if(this.closed) return cb && setImmediate(cb);
     super.close(()=>{
       this._node.close(() => {
-        timer.shutdown(() => {
+        this._timers.shutdown(() => {
           debug('closing server')
           this.closed = true
           cb && cb()

--- a/lib/server/node.js
+++ b/lib/server/node.js
@@ -181,6 +181,13 @@ if (!handle) return;
       this._ring.destroy();
     })
   }
+
+
 }
 
+Object.defineProperty(Node.prototype, 'name', {
+  get: function() {
+    return this._app;
+  }
+})
 module.exports = Node;

--- a/lib/server/response.js
+++ b/lib/server/response.js
@@ -18,7 +18,7 @@ Response.prototype.error = function error( err, msg ) {
   }
   
   this.status( err.statusCode );
-  this.res.setHeader('x-reason', err.message)
+  this.res.setHeader('x-skyring-reason', err.message)
   return this.end()
 }
 

--- a/lib/server/response.js
+++ b/lib/server/response.js
@@ -11,7 +11,6 @@ Response.prototype.error = function error( err, msg ) {
       message: msg 
     })
   }
-
   err.statusCode = err.statusCode || err.code;
   if( !err.statusCode ) {
     err.statusCode = 500;
@@ -19,9 +18,8 @@ Response.prototype.error = function error( err, msg ) {
   }
   
   this.status( err.statusCode );
-  return this.json({
-    message: err.message
-  });
+  this.res.setHeader('x-reason', err.message)
+  return this.end()
 }
 
 Response.prototype.get = function get( key ) {

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -59,6 +59,7 @@ Route.prototype.process = function process( req, res, node, next ) {
          run(++idx);
       });
     } catch ( err ){
+      console.error(err)
       err.statusCode = err.statusCode || 500;
       return next( err );
     }

--- a/lib/server/route.js
+++ b/lib/server/route.js
@@ -59,7 +59,6 @@ Route.prototype.process = function process( req, res, node, next ) {
          run(++idx);
       });
     } catch ( err ){
-      console.error(err)
       err.statusCode = err.statusCode || 500;
       return next( err );
     }

--- a/lib/server/router.js
+++ b/lib/server/router.js
@@ -21,10 +21,11 @@ const Route    = require('./route')
  * @param {module:skyring/lib/server/node} node The node linked to the application hashring
  * @example var x = new Router(node)
  */
-function Router( node, opts ) {
+function Router( node, timers ) {
   this.routes        = new Map();
   this.route_options = new Map();
   this.node          = node;
+  this.timers        = timers
 };
 
 /**
@@ -125,6 +126,8 @@ http.createServer((req, res) => {
 Router.prototype.handle = function handle( req, res ) {
   req.$ = new Request( req );
   res.$ = new Response( res );
+  req.$.timers = this.timers;
+  
   const path = req.$.path;
   const method = req.method.toUpperCase();
   const map = this.routes.get( method );

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -28,7 +28,7 @@ class Timer extends Map {
   constructor(options = {}, ...args) {
     super(...args);
     this.options = Object.assign({}, {
-      
+      nats: null
     }, options);
     this._sid = null;
     this._bail = false;
@@ -198,7 +198,6 @@ class Timer extends Map {
   watch( key, cb ){
     if( this._bail ) return;
     const opts = {queue: key};
-    console.log('queue group', key)
     this._sid = this.nats.subscribe('skyring', opts, ( data ) => {
       if( this._bail ) return;
       const value = json.parse( data );

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -11,7 +11,7 @@
  * @requires skyring/lib/json
  */
 const transports = require('./transports')
-    , nats      = require('./nats')
+    , nats       = require('./nats')
     , json       = require('./json')
     , debug      = require('debug')('skyring:timer')
     , rebalance  = require('debug')('skyring:rebalance')

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -1,4 +1,4 @@
-/*jshint laxcomma: true, smarttabs: true, node:true, esnext:true*/
+/*jshint laxcomma: true, smarttabs: true, node:true, esnext:true, unused: true*/
 'use strict';
 /**
  * Manage Timers on a node
@@ -16,188 +16,197 @@ const transports = require('./transports')
     , debug      = require('debug')('skyring:timer')
     , rebalance  = require('debug')('skyring:rebalance')
     , noop       = function(){}
-    , cache      = new Map()
     ;
 
-let BAIL = false
-let NATS_SID = null
 /**
  * Node style callback
  * @typedef {Function} Nodeback
  * @property {?Error} [err] An error instance. If not null, the results should not be trusted 
  * @property {Object} result The results of the function execution
  **/
-
-/**
- * Sets a new time instance. If The timer has lapsed, it will be executed immediately
- * @method module:skyring/lib/timer#create
- * @param {String} id A unique Id of the time
- * @param {Object} body Configuration options for the timer instance
- * @param {Number} body.timeout Duration in milisecods to delay execution of the timer
- * @param {String} body.data The data to be assicated with the timer, when it is executed
- * @param {Object} callback Options for the outbound transport for the timer when it executes
- * @param {String} callback.transport The transport type ( http, etc )
- * @param {String} transport.method The method the transport should use when executing the timer
- * @param {String} transport.uri The target uri for the transport when the timer executes 
- * @param {Nodeback} callback
- **/
-exports.create = function create(id, body, cb) {
-  const payload = body;
-  const transport = transports[payload.callback.transport];
-  if (cache.has(id)) {
-    const err = new Error('Key exists');
-    err.code = 'EKEYEXISTS';
-    return setImmediate(cb, err)
-  }
-  const now = Date.now();
-  const created = payload.created || now;
-  const elapsed = now - created
-  if( now > created + payload.timeout ){
-    debug('executing stale timer')
-    setImmediate(
-        transport
-      , payload.callback.method
-      , payload.callback.uri
-      , payload.data
-      , id
-    );
-    return cb(null)
+class Timer extends Map {
+  constructor(options = {}, ...args) {
+    super(...args);
+    this.options = Object.assign({}, {
+      
+    }, options);
+    this._sid = null;
+    this._bail = false;
+    this.nats = nats.createClient(this.options.nats);
   }
 
-  debug('setting timer', id);
-  cache.set( id, {
-    payload: payload
-  , created: Date.now()
-  , id: id
-  , timer: setTimeout(
-            transport
-          , payload.timeout - elapsed
-          , payload.callback.method
-          , payload.callback.uri
-          , payload.data
-          , id
-          ).unref()
-  });
-  setImmediate(cb, null);
-}
+  /**
+   * Sets a new time instance. If The timer has lapsed, it will be executed immediately
+   * @method module:skyring/lib/timer#create
+   * @param {String} id A unique Id of the time
+   * @param {Object} body Configuration options for the timer instance
+   * @param {Number} body.timeout Duration in milisecods to delay execution of the timer
+   * @param {String} body.data The data to be assicated with the timer, when it is executed
+   * @param {Object} callback Options for the outbound transport for the timer when it executes
+   * @param {String} callback.transport The transport type ( http, etc )
+   * @param {String} transport.method The method the transport should use when executing the timer
+   * @param {String} transport.uri The target uri for the transport when the timer executes 
+   * @param {Nodeback} callback
+   **/
+  create(id, body, cb) {
+    const payload = body;
+    const transport = transports[payload.callback.transport];
+    if (this.has(id)) {
+      const err = new Error('Key exists');
+      err.code = 'EKEYEXISTS';
+      return setImmediate(cb, err);
+    }
+    const now = Date.now();
+    const created = payload.created || now;
+    const elapsed = now - created;
+    if( now > created + payload.timeout ){
+      debug('executing stale timer');
+      setImmediate(
+          transport
+        , payload.callback.method
+        , payload.callback.uri
+        , payload.data
+        , id
+        , this
+      );
+      return cb(null);
+    }
 
-
-/**
- * Cancels a specific timer
- * @method module:skyring/lib/timer#delete
- * @param {String} id The id of the timer to cancel
- * @param {Nodeback} callback Node style callback to execute
- **/
-exports.delete = function(id, cb) {
-  const t = cache.get(id);
-  if( !t ) {
-    const err = new Error('Not Found');
-    err.code = 'ENOENT';
-    return cb && setImmediate(cb, err);
-  }
-  clearTimeout(t.timer);
-  cache.delete(id);
-  debug('timer cleared', id)
-  cb && setImmediate(cb, null);
-}
-
-
-exports.rebalance = function(opts, node, cb) {
-  const callback = cb || noop
-      , size = cache.size
-      , client = nats.client
-      ;
-
-  if( !size ) return;
-  const records = cache.values();
-  const run = ( obj ) => {
-    if (node.owns(obj.id)) return;
-    clearTimeout( obj.timer );
-    cache.delete( obj.id );
-    const data = Object.assign({}, obj.payload, {
-      id: obj.id
-    , created: obj.created
+    debug('setting timer', id);
+    this.set( id, {
+      payload: payload
+    , created: Date.now()
+    , id: id
+    , timer: setTimeout(
+              transport
+            , payload.timeout - elapsed
+            , payload.callback.method
+            , payload.callback.uri
+            , payload.data
+            , id
+            , this
+            ).unref()
     });
-    rebalance('no longer the owner of %s', obj.id);
-    cb(data)
+    setImmediate(cb, null);
   }
 
-  for( var record of records ) {
-    run( record );
+  /**
+   * Cancels a specific timer
+   * @method module:skyring/lib/timer#delete
+   * @param {String} id The id of the timer to cancel
+   * @param {Nodeback} callback Node style callback to execute
+   **/
+  remove(id, cb) {
+    const t = this.get(id);
+    if( !t ) {
+      const err = new Error('Not Found');
+      err.code = 'ENOENT';
+      return cb && setImmediate(cb, err);
+    }
+    clearTimeout(t.timer);
+    this.delete(id);
+    debug('timer cleared', id);
+    cb && setImmediate(cb, null);
   }
-}
-/**
- * Updates a timer inplace
- * @method module:skyring/lib/timer#update
- * @param {String} id A unique Id of the time
- * @param {Object} body Configuration options for the timer instance
- * @param {Number} body.timeout Duration in milisecods to delay execution of the timer
- * @param {String} body.data The data to be assicated with the timer, when it is executed
- * @param {Object} callback Options for the outbound transport for the timer when it executes
- * @param {String} callback.transport The transport type ( http, etc )
- * @param {String} transport.method The method the transport should use when executing the timer
- * @param {String} transport.uri The target uri for the transport when the timer executes 
- * @param {Nodeback} callback
- **/
-exports.update = function update(id, body, cb){
-  exports.delete(id, (err) => {
-    if (err) return cb(err);
-    debug('updating timer', id);
-    exports.create(id, body, cb);
-  })
-}
 
-/**
- * Triggers timers to be rebalanced with in the ring before sutdown, and cancels all locally pending timers
- * @method module:skyring/lib/timer#shutdown
- * @param {Nodeback} callback Node style callback to execute when the function is complete
- **/
-exports.shutdown = function shutdown(cb) {
-  const size = cache.size;
-  const client = nats.client;
-  let sent = 0;
-  let acks = 0
+  rebalance(opts, node, cb) {
+    const callback = cb || noop
+        , size = this.size
+        ;
 
-  if( !size ) return cb();
+    if( !size ) return;
+    const records = this.values();
+    const run = ( obj ) => {
+      if (node.owns(obj.id)) return;
+      clearTimeout( obj.timer );
+      this.delete( obj.id );
+      const data = Object.assign({}, obj.payload, {
+        id: obj.id
+      , created: obj.created
+      });
+      rebalance('no longer the owner of %s', obj.id);
+      callback(data);
+    };
 
-  client.unsubscribe( NATS_SID );
-  NATS_SID = null;
-
-  const run = ( obj ) => {
-    clearTimeout( obj.timer );
-    const data = Object.assign({}, obj.payload, {
-      id: obj.id
-    , created: obj.created
-    , count: ++sent
-    });
-
-    nats.client.publish('skyring', JSON.stringify( data ), () => {
-      rebalance( '%s of %s processed', data.count, size );
-      if( ++acks === size ) return setImmediate( nats.quit, cb )
+    for( var record of records ) {
+      run( record );
+    }
+  }
+  /**
+   * Updates a timer inplace
+   * @method module:skyring/lib/timer#update
+   * @param {String} id A unique Id of the time
+   * @param {Object} body Configuration options for the timer instance
+   * @param {Number} body.timeout Duration in milisecods to delay execution of the timer
+   * @param {String} body.data The data to be assicated with the timer, when it is executed
+   * @param {Object} callback Options for the outbound transport for the timer when it executes
+   * @param {String} callback.transport The transport type ( http, etc )
+   * @param {String} transport.method The method the transport should use when executing the timer
+   * @param {String} transport.uri The target uri for the transport when the timer executes 
+   * @param {Nodeback} callback
+   **/
+  update(id, body, cb){
+    this.remove(id, (err) => {
+      if (err) return cb(err);
+      debug('updating timer', id);
+      this.create(id, body, cb);
     });
   }
 
-  for( var record of cache.values() ) {
-    run( record );
+  /**
+   * Triggers timers to be rebalanced with in the ring before sutdown, and cancels all locally pending timers
+   * @method module:skyring/lib/timer#shutdown
+   * @param {Nodeback} callback Node style callback to execute when the function is complete
+   **/
+  shutdown(cb) {
+    const size = this.size;
+    const client = this.nats;
+    let sent = 0;
+    let acks = 0;
+
+    if( !size ) return cb();
+
+    client.unsubscribe( this._sid );
+    this._sid = null;
+
+    const run = ( obj ) => {
+      clearTimeout( obj.timer );
+      const data = Object.assign({}, obj.payload, {
+        id: obj.id
+      , created: obj.created
+      , count: ++sent
+      });
+
+      this.nats.publish('skyring', JSON.stringify( data ), () => {
+        rebalance( '%s of %s processed', data.count, size );
+        if( ++acks === size ) return setImmediate( nats.quit, cb );
+      });
+    };
+
+    for( var record of this.values() ) {
+      run( record );
+    }
+    this.clear();
   }
-  cache.clear();
+
+  /**
+   * Starts an internal queue on a redis key to listen for incoming timers from a node rebalance
+   * @method module:skyring/lib/timer#watch
+   * @param {String} key The key name in redis to use as a timer queue
+   * @param {Nodeback} callback Node style callback to execute when the function has finished execution
+   **/
+  watch( key, cb ){
+    if( this._bail ) return;
+    const opts = {queue: key};
+    console.log('queue group', key)
+    this._sid = this.nats.subscribe('skyring', opts, ( data ) => {
+      if( this._bail ) return;
+      const value = json.parse( data );
+      rebalance( 'received %s', value.value.count );
+      cb( value.error, value.value );
+    });
+    return this._sid;
+  }
 }
 
-/**
- * Starts an internal queue on a redis key to listen for incoming timers from a node rebalance
- * @method module:skyring/lib/timer#watch
- * @param {String} key The key name in redis to use as a timer queue
- * @param {Nodeback} callback Node style callback to execute when the function has finished execution
- **/
-exports.watch = function( key, cb ){
-  if( BAIL ) return;
-  const opts = {queue: 'skyring'};
-  NATS_SID = nats.client.subscribe('skyring', opts, ( data ) => {
-    if( BAIL ) return;
-    const value = json.parse( data );
-    rebalance( 'received %s', value.value.count );
-    cb( value.error, value.value );
-  });
-  return NATS_SID
-}
-
+module.exports = Timer;

--- a/lib/transports/callback.js
+++ b/lib/transports/callback.js
@@ -7,6 +7,6 @@
  * @since 1.0.4
  */
 
-module.exports = function callback( method, url, payload, id ){
+module.exports = function callback( method, url, payload, id, cache ){
 	setImmediate(payload[method], url, id)
 }

--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -13,7 +13,6 @@
 
 const STATUS_CODES = require('http').STATUS_CODES
     , request = require('request')
-    , timer   = require('../timer')
     , debug   = require('debug')('skyring:transport:http')
     ;
 
@@ -26,7 +25,7 @@ const STATUS_CODES = require('http').STATUS_CODES
  * @param {String} payload The data payload to include in the request
  * @param {String} id The id of the timer being executed
  **/
-module.exports = function makeRequest( method, url, payload, id) {
+module.exports = function makeRequest( method, url, payload, id, cache) {
   const isJSON = typeof payload === 'object'
   const options = {
     body: payload || ""
@@ -36,17 +35,17 @@ module.exports = function makeRequest( method, url, payload, id) {
   request[method](url, options, (err, res, body) => {
     if(err){
       debug('timer fail');
-      return timer.delete(id);
+      return cache.remove(id);
     }
     if(res.statusCode > 299 ){
       debug('timer fail');
       const err = new Error(STATUS_CODES[res.statusCode])
       err.code = res.statusCode = res.statusCode;
       console.error(err, body)
-      return timer.delete(id);
+      return cache.remove(id);
     }
 
     debug('timer sucess');
-    return timer.delete(id);
+    return cache.remove(id);
   });
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "uuid": "^3.0.1"
   },
   "devDependencies": {
+    "async": "^2.1.4",
     "mocha": "^3.2.0",
     "supertest": "^2.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "skyring": "./bin/skyring.js"
   },
   "scripts": {
-    "test": "mocha --recursive test/",
+    "test": "node ./test.js",
     "start": "npm run compose:up",
     "stop": "npm run compose:down",
     "test:ci": "docker-compose -f compose/test.yml up --abort-on-container-exit --build",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,24 @@
+var child_process = require('child_process')
+  , fs = require('fs')
+  , util = require("util")
+  , production = (process.env.NODE_ENV === 'test')
+  , html
+  , reporter
+  , coverage
+  , mocha
+  , env
+  ;
+
+env = Object.assign({}, process.env );
+env.MOCHA_COLORS = 1;
+reporter = process.stdout;
+mocha = child_process.spawn("mocha", [
+  "--recursive"
+, '--reporter=spec'
+, 'test/*.spec.js'
+],{env:env})
+mocha.on('exit', function( code ){
+    process.exit( code );
+})
+mocha.stdout.pipe( reporter );
+mocha.stderr.pipe( reporter );

--- a/test/integration/post-timer.spec.js
+++ b/test/integration/post-timer.spec.js
@@ -6,6 +6,28 @@ const http = require('http')
     , Server = require('../../lib')
     ;
 
+function toServer(port, expect = 'hello', method = 'post', time = 1000, cb){
+  const start = Date.now()
+  const s = http.createServer((req, res) => {
+    let data = ''
+      , now = Date.now()
+      ;
+
+    res.writeHead(200);
+    res.end('ok');
+    assert.equal(req.method.toLowerCase(), method);
+    req.on('data', (chunk) => {
+      data += chunk
+    });
+    req.on('end', () => {
+      assert.ok(now - start > time, `expected > ${time} got ${now-start}`)
+      assert.equal(data, expect);
+      s.close( cb )
+    });
+  }).listen(port);
+  return s
+}
+
 describe('skyring:api', function() {
   this.timeout(4000)
   let request, server
@@ -20,44 +42,110 @@ describe('skyring:api', function() {
   });
 
   describe('#POST /timer', function(){
-    this.timeout(3000);
-    it('should set a timer postback - 1000ms', ( done ) => {
-      let start;
-      const s = http.createServer((req, res) => {
-        let data = ''
-          , now = Date.now()
-          ;
+    let sone, stwo, sthree
+    var os = require('os')
+    var hostname;
+    if(!process.env.TEST_HOST) {
+      hostname =  os.hostname()
+      console.log(`env variable TEST_HOST not set. using ${hostname} as hostname`)
+    } else {
+      hostname = process.env.TEST_HOST;
+    }
+    describe('valid request', function(){
+      this.timeout(3000);
+      it('should set a timer postback (201)', ( done ) => {
+        toServer(9999, 'hello', 'post', 1000, done)
+        request
+          .post('/timer')
+          .send({
+            timeout: 1000
+          , data: 'hello'
+          , callback: {
+              uri: `http://${hostname}:9999`
+            , method: 'post'
+            , transport: 'http'
+            }
+          })
+          .expect(201)
+          .end((err, res) => {
+            assert.ifError(err);
+            assert.ok(res.headers.location)
+          });
+      });
 
-        res.writeHead(200);
-        res.end('ok');
-        assert.equal(req.method.toLowerCase(), 'post');
-        req.on('data', (chunk) => {
-          data += chunk
-        });
-        req.on('end', () => {
-          assert.equal(data, 'hello');
-          assert.ok(now - start > 1000, `expected > 1000 got ${now-start}`)
-          s.close( done )
-        });
+      it('should allow request with no data - (201)', (done) => {
+        toServer(9999, '', 'post', 2000, done)
+        request
+          .post('/timer')
+          .send({
+            timeout: 2000
+          , callback: {
+              uri: `http://${hostname}:9999`
+            , method: 'post'
+            , transport: 'http'
+            }
+          })
+          .expect(201)
+          .end((err, res) => {
+            assert.ifError(err);
+            assert.ok(res.headers.location)
+          });
+      });
 
-      }).listen(9999);
-      start = Date.now()
-      request
-        .post('/timer')
-        .send({
-          timeout: 1000
-        , data: 'hello'
-        , callback: {
-            uri: 'http://node-5:9999'
-          , method: 'post'
-          , transport: 'http'
-          }
-        })
-        .expect(201)
-        .end((err, res) => {
-           assert.ifError(err);
-           assert.ok(res.headers.location)
-        });
-    });
+      it('should allow request with timeout - (400)', (done) => {
+        request
+          .post('/timer')
+          .send({
+            callback: {
+              uri: `http://${hostname}:9999`
+            , data: 'fake'
+            , method: 'post'
+            , transport: 'http'
+            }
+          })
+          .expect(400)
+          .end((err, res) => {
+            assert.equal(typeof res.headers['x-skyring-reason'], 'string')
+            done()            
+          });
+      });
+
+      it('should allow request with no callback uri - (400)', (done) => {
+        request
+          .post('/timer')
+          .send({
+            callback: {
+              timeout: 3000
+            , data: 'fake'
+            , method: 'post'
+            , transport: 'http'
+            }
+          })
+          .expect(400)
+          .end((err, res) => {
+            assert.equal(typeof res.headers['x-skyring-reason'], 'string')
+            done()            
+          });
+      });
+
+      it('should allow request with no transport - (400)', (done) => {
+        request
+          .post('/timer')
+          .send({
+            callback: {
+              timeout: 3000
+            , data: 'fake'
+            , method: 'post'
+            }
+          })
+          .expect(400)
+          .end((err, res) => {
+            assert.equal(typeof res.headers['x-skyring-reason'], 'string')
+            done()            
+          });
+      });
+
+    })
+
   });
 });

--- a/test/integration/post-timer.spec.js
+++ b/test/integration/post-timer.spec.js
@@ -6,7 +6,8 @@ const http = require('http')
     , Server = require('../../lib')
     ;
 
-describe('skyring:api', () => {
+describe('skyring:api', function() {
+  this.timeout(4000)
   let request, server
   before(( done ) => {
     server = new Server();

--- a/test/server.spec.js
+++ b/test/server.spec.js
@@ -1,0 +1,125 @@
+'use strict'
+
+const assert = require('assert')
+    , http = require('http')
+    , supertest = require('supertest')
+    , Server = require('../lib/server')
+    , async = require('async')
+
+
+describe('server', () => {
+  let sone, stwo, sthree
+
+  before((done) => {
+    sone = new Server({
+      node: {
+        port: 4444
+      , host: '127.0.0.1'
+      , app: 'spec'
+      }
+      , seeds: ['127.0.0.1:4444', '127.0.0.1:4445']
+    })
+    .load()
+    .listen(5555);
+
+    stwo = new Server({
+      node:{
+        port: 4445
+      , host: '127.0.0.1'
+      , app: 'spec'
+      }
+      , seeds: ['127.0.0.1:4444', '127.0.0.1:4445']
+    })
+    .load()
+    .listen(5556);
+    
+    sthree = new Server({
+      node: {
+        port: 4446
+      , host: '127.0.0.1'
+      , app: 'spec'
+      }
+      , seeds: ['127.0.0.1:4444', '127.0.0.1:4445']
+    })
+    .load()
+    .listen(5557, null, null, () => {
+      done();
+    });
+
+  })
+
+  after((done) => {
+    sone.close(() => {
+      stwo.close(() => {
+        sthree.close(done);
+      });
+    });    
+  });
+
+  it('should bootstrap server nodes', (done) => {
+    assert.ok(sone);
+    assert.ok(stwo);
+    assert.ok(sthree);
+    done();
+  })
+
+  describe('rebalance', () => {
+    let max = 50, count = 0, postback
+    before((done) => {
+      postback = http.createServer((req, res) => {
+        count++;
+        res.writeHead(200)
+        res.end();
+      }).listen( 2222, done );
+
+    })
+
+    after(( done ) => {
+      postback.close( done );
+    })
+    
+    it('should service a lost node', ( done ) => {
+      async.until(
+        () => { return !max},
+        (callback) => {
+          const request = supertest('http://localhost:5557');
+          request
+            .post('/timer')
+            .send({
+              timeout: 250
+            , data: 'data'
+            , callback: {
+                uri: 'http://localhost:2222'
+              , method: 'post'
+              , transport: 'http'
+              }
+            })
+            .expect(201)
+            .end((err, res) => {
+              assert.ifError(err);
+              max--;
+              callback();
+            })
+        },
+        ( err ) => {
+          assert.ifError(err);
+          sthree.close( () => {
+            async.until(
+              function(){
+                return count === 50;
+              },
+              function(cb){
+                setImmediate(cb)
+              },
+              function(err){
+                assert.equal(max, 0, 'max should be 0');
+                assert.equal(count, 50, 'count should be 50')
+                done();
+              }
+            ) 
+          })
+        }
+      );
+    });
+  });
+});

--- a/test/timer.spec.js
+++ b/test/timer.spec.js
@@ -1,12 +1,24 @@
 const assert = require('assert')
     , uuid   = require('uuid')
-    , timer  = require('../lib/timer');
+    , Timer  = require('../lib/timer');
 
 describe('timers', () => {
+  let timers;
+  beforeEach(() => {
+    timers = new Timer();
+  })
+
+  afterEach(() => {
+    for(var t of timers.values()){
+      clearTimeout(t.timer);
+    }
+    timers.clear();
+  });
+
   describe('create', () => {
     it('Execute the transport on a delay', (done) => {
       const id = uuid.v4()
-      timer.create(
+      timers.create(
         id
       , {
           timeout: 250
@@ -39,7 +51,7 @@ describe('timers', () => {
       }
       const id = uuid.v4();
 
-      timer.create(
+      timers.create(
         id
       , {
           timeout: 100
@@ -52,7 +64,7 @@ describe('timers', () => {
         }
       , () => {
 
-        timer.update(
+        timers.update(
           id
         , {
             timeout: 150
@@ -70,11 +82,11 @@ describe('timers', () => {
     })
   });
 
-  describe('delete', () => {
+  describe('remove', () => {
     it('should cancel an existing timer', (done) => {
       const id = uuid.v4()
       let called = false
-      timer.create(
+      timers.create(
         id
       , {
           timeout: 1000
@@ -92,7 +104,7 @@ describe('timers', () => {
         }
       , () => {
           setTimeout(() => {
-            timer.delete(id, () => {
+            timers.remove(id, () => {
               assert.equal(called, false)
               done()
             })


### PR DESCRIPTION
Spinning up tests we need to have better ways of creating instances on the fly and isolating them from eachother.

As a result, the timers module needs to be converted into a class so we can have multiple queue groups and timer caches. 