### PR TITLE
Move test runner out of docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,18 @@ sudo: required
 services:
   - docker
 
-script: npm run test:ci
+script: npm test
 language: node_js
-after_install:
-  - docker-compose -f compose/test.yml down
+before_script:
+  - docker-compose -f compose/nats.yml up -d
+after_script:
+  - docker-compose -f compose/nats.yml down
 git:
   depth: 3
 node_js:
   - "6"
   - "7"
+  - "8"
 addons:
   code_climate:
     repo_token: 248135f96061f77d2e5f78526432fd096785d2914d8f5a73a04c061000939d5d

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -58,8 +58,6 @@ class Timer extends Map {
     }, options);
     this._sid = null;
     this._bail = false;
-    this.nats = nats.createClient( this.options.nats );
-    this.transports = new Transports(this.options.transports);
     const store_opts = conf.get('storage');
     const opts = Object.assign(store_opts, this.options.storage);
     store(opts);
@@ -76,6 +74,8 @@ class Timer extends Map {
       }
     }
     debug('storage path', opts);
+    this.nats = nats.createClient( this.options.nats );
+    this.transports = new Transports(this.options.transports);
     this[storage] = levelup(opts.path, {
       valueEncoding: 'json'
     , db: require( opts.backend )

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -45,7 +45,7 @@ const os         = require('os')
  * @param {String} options.storage.path A directory path to a leveldb instance. One will be created if it doesn't already exist.
  * If the backend is memdown, this is optional and randomly generated per timer instance
  * @param {Function} [onReady=()=>{}] A callback function to call after initial recovery has completed
- * @param {String[]|Function[]} [optsion.transports] an array of custom transport functions, or requireable paths that resolve to functions. All transport function must be named functions
+ * @param {String[]|Function[]} [options.transports] an array of custom transport functions, or requireable paths that resolve to functions. All transport function must be named functions
  * If not specified, configuration values will be used
  **/
 class Timer extends Map {

--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -45,11 +45,11 @@ module.exports = class Transports {
         throw new Error('Transports must accept five parameters');
       }
 
-      if (typeof transport.name !== 'string' && transport.name.length <= 0) {
+      if (typeof transport.name !== 'string' || transport.name.length <= 0) {
         throw new TypeError('transports.name is required and must be a string');
       }
 
-      if (hasOwn(exports, transport.name)) {
+      if (hasOwn(this, transport.name)) {
         const error = new Error(`A transport with name ${transport.name} is already defined`);
         error.name = 'EEXIST';
         throw error;

--- a/test/integration/delete-timer.spec.js
+++ b/test/integration/delete-timer.spec.js
@@ -20,7 +20,9 @@ if (!process.env.TEST_HOST) {
 test('skyring:api', (t) => {
   let server, request;
   t.test('set up skyring server', (tt) => {
-    server = new Server();
+    server = new Server({
+      seeds: [`${hostname}:3455`]
+    });
     request = supertest('http://localhost:4444')
     server.load().listen(4444, null, null, tt.end);
   });

--- a/test/integration/post-timer.spec.js
+++ b/test/integration/post-timer.spec.js
@@ -45,7 +45,9 @@ function toServer(port, expect = 'hello', method = 'post', time = 1000, t){
 test('skyring:api', (t) => {
   let request, server
   t.test('setup skyring server', (tt) => {
-    server = new Server();
+    server = new Server({
+      seeds: [`${hostname}:3455`]
+    });
     request = supertest('http://localhost:3333');
     server.load().listen(3333, null, null, tt.end)
   });

--- a/test/integration/put-timer.spec.js
+++ b/test/integration/put-timer.spec.js
@@ -20,7 +20,7 @@ if(!process.env.TEST_HOST) {
 test('skyring:api', (t) => {
   let server, request;
   t.test('set up ring server', ( tt ) => {
-    server = new Server();
+    server = new Server({ seeds: [`${hostname}:3455`] });
     request = supertest('http://localhost:5544');
     server.load().listen(5544, null, null, tt.end);
   });

--- a/test/unit/dummy.transport
+++ b/test/unit/dummy.transport
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/unit/server.spec.js
+++ b/test/unit/server.spec.js
@@ -8,7 +8,7 @@ const crypto    = require('crypto')
     , async     = require('async')
     , conf      = require('keef')
     , tap       = require('tap')
-    , Server    = require('../lib/server')
+    , Server    = require('../../lib/server')
     , test      = tap.test
 
 

--- a/test/unit/timer.spec.js
+++ b/test/unit/timer.spec.js
@@ -6,7 +6,7 @@ const os = require('os')
     , tap = require('tap')
     , uuid   = require('uuid')
     , conf   = require('keef')
-    , Timer  = require('../lib/timer')
+    , Timer  = require('../../lib/timer')
     , test   = tap.test
     ;
 

--- a/test/unit/transports.spec.js
+++ b/test/unit/transports.spec.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const path = require('path')
+const { test } = require('tap')
+const Transports = require('../../lib/transports')
+
+test('transports', (t) => {
+  t.throws(() => {
+    new Transports([
+      path.join(__dirname, 'dummy.transport')
+    ])
+  }, /A Transport must export a function/)
+
+  t.throws(() => {
+    new Transports([
+      () => {}
+    ])
+  }, /Transports must accept five parameters/)
+
+  t.throws(() => {
+    new Transports([
+      (a, b, c, d, e) => {}
+    ])
+  }, /transports.name is required and must be a string/)
+
+  t.throws(() => {
+    new Transports([
+      function test(a, b, c, d, e) {}
+    , function test(a, b, c, d, e) {}
+    ])
+  }, /A transport with name test is already defined/)
+  t.end()
+})


### PR DESCRIPTION
The docker set up wasn't really reliable in Travis. Failures would get missed and seemingly pass.
Just running the tests with a single seed node so they don't wait to start. And Test coverage was unreliable in larger clusters as there are cases where the node that is running the tests is not the node that executes the code.

Bumping test coverage up a bit to be in line with latest changes