### PR TITLE
timer, server: push server start up logic   into the listen function

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ if( require.main === module ){
 
   const server = new Server();
 
-  server.load().listen(conf.get('PORT'), (err) => {
+  server.listen(conf.get('PORT'), (err) => {
     if(err) {
       process.exitCode = 1;
       console.error(err);

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -12,8 +12,10 @@
  */
 
 const http   = require('http')
+    , util   = require('util')
     , Debug  = require('debug')
     , mock   = require('./mock')
+    , routes = require('./api')
     , Node   = require('./node')
     , Router = require('./router')
     , Timer  = require('../timer')
@@ -83,43 +85,13 @@ class Server extends http.Server {
       this._node = new Node();
     }
     this._group = this._node.name;
-    this._timers = new Timer({
-      nats: this.options.nats
-    , storage: this.options.storage
-    , transports: this.options.transports
-    });
-    this._router = new Router(this._node, this._timers);
-    this._node.on('ringchange', (evt) => {
-      this._timers.rebalance(evt, this._node, (data) => {
-        this.proxy(data);
-      });
-    });
     this._node.on('bootstrap', (seeds) => {
       this.emit('bootstrap', seeds);
     });
-  }
 
-  /**
-   * loads application routes if not already loaded
-   * @method module:skyring/lib/server#load
-   * @return {module:skyring/lib/server}
-   **/
-  load() {
-    if( this.loaded ) return this;
-    const routes = require('./api');
-    Object.keys(routes)
-          .forEach((name) => {
-            const item = routes[name];
-            const route = this._router.route(
-              item.path
-            , item.method
-            , item.handler
-            );
-
-            item.middleware && route.before( item.middleware );
-          });
-
-    return this;
+    this.load = util.deprecate(() => {
+      return this
+    }, 'server#load is deprecated and will be removed in future version')
   }
 
   /**
@@ -134,18 +106,42 @@ class Server extends http.Server {
   listen(port, ...args) {
     const callback = args[args.length - 1]
     debug('seed nodes', this.options.seeds);
-    this._node.join(this.options.seeds, (err) => {
-      if (err) {
-        console.error(err);
-        return typeof callback === 'function' ? callback(err) : null;
+
+    this._timers = new Timer({
+      nats: this.options.nats
+    , storage: this.options.storage
+    , transports: this.options.transports
+    }, (err) => {
+      if (err) return typeof callback === 'function' ? callback(err) : null;
+      this._router = new Router(this._node, this._timers);
+      for (const key of Object.keys(routes)) {
+        const item = routes[key]
+        const route = this._router.route(
+          item.path
+        , item.method
+        , item.handler
+        );
+
+        item.middleware && route.before( item.middleware );
       }
-      this._node.handle(( req, res ) => {
-        this._router.handle( req, res );
+      this._node.on('ringchange', (evt) => {
+        this._timers.rebalance(evt, this._node, (data) => {
+          this.proxy(data);
+        });
       });
-      this._timers.watch(`skyring:${this._group}`, (err, data) => {
-        this.proxy(data);
+      this._node.join(this.options.seeds, (err) => {
+        if (err) {
+          console.error(err);
+          return typeof callback === 'function' ? callback(err) : null;
+        }
+        this._node.handle(( req, res ) => {
+          this._router.handle( req, res );
+        });
+        this._timers.watch(`skyring:${this._group}`, (err, data) => {
+          this.proxy(data);
+        });
+        super.listen(port, ...args);
       });
-      super.listen(port, ...args);
     });
     return this;
   }

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -105,9 +105,7 @@ class Timer extends Map {
     this[kNode] = generateId(store_opts.path)
     this.nats = nats.createClient( this.options.nats );
     this.transports = new Transports(this.options.transports);
-    this[storage] = levelup(backend, opts)
-
-    this[storage].once('ready', () => {
+    this[storage] = levelup(backend, opts, (err) => {
       store('storage backend ready', store_opts);
       debug('node id', this[kNode])
       this.recover(() => {
@@ -116,7 +114,8 @@ class Timer extends Map {
         , type: EVENT_STATUS.READY
         }), cb)
       });
-    });
+    })
+
   }
 
   /**


### PR DESCRIPTION
deprecate the use of the load function and pass callback from the listen
function to ensure server start happens after storage has loaded

Fix: #16