### PR TITLE
Enforce upper bound on timer timeout values

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 * [API Docs](https://esatterwhite.github.io/skyring/api)
 
 # Skyring
-A distributed reliable timer service providing similar functionality to using `setTimeout`.
-`Skyring` servers are clustered  into a *hashring* using consistent hashing to partition timers to specific nodes in the ring.  Skyring exposes a simple HTTP API That allows to you create and cancel timers. Timer execution comes in to the form of an HTTP webhook ( more transports to come )
+A distributed reliable timer service providing `setTimeout` functionality in a distributed fashion.
+`Skyring` servers are clustered into a *hashring* using consistent hashing to partition timers to specific nodes in the ring.  Skyring exposes a simple HTTP API that allows to you create and cancel timers. Timer execution comes in to the form of an HTTP webhook ( more transports to come )
 
 # Architechture Overview 
 
@@ -126,6 +126,10 @@ between 2K - 5K requests per second.
 ##### **POST `/timer`**
 
 **Request**
+
+Since timers managed in `Skyring` are done so through the use of `setTimeout`, there is a maximum `timeout` value of `2^31 - 1` or
+`2147483647` milliseconds, which is approximately `24.8` days. Attempting to request a timeout great than this value will result in a
+`400 Bad Request` response. Additionally, the `timeout` must be greater than `0`.
 
 ```bash
 curl -i -XPOST http://localhost:8080/timer -d '{

--- a/lib/server/api/post_timer.js
+++ b/lib/server/api/post_timer.js
@@ -24,7 +24,7 @@ module.exports = {
  * @apiName create_timer
  * @api {post} /timer Create a new timer
  * @apiVersion 1.0.0
- * @apiParam {Number} timeout the time in miliseconds before the timer executes
+ * @apiParam {Number} timeout the time in milliseconds from now the timer should execute. This must be in the range: 0 < timeout < 2^31 - 1.
  * @apiParam {String} data a data payload to include with the timer when it executes
  * @apiParam {Object} callback
  * @apiParam {String} callback.transport The delivery transport to use when executing the timer

--- a/lib/server/api/put_timer.js
+++ b/lib/server/api/put_timer.js
@@ -34,7 +34,7 @@ module.exports = {
  * @apiName put_timer
  * @api {put} /timer/:id Update a new timer in place
  * @apiVersion 1.0.0
- * @apiParam {Number} timeout the time in miliseconds before the timer executes
+ * @apiParam {Number} timeout the time in milliseconds from now the timer should execute. This must be in the range: 0 < timeout < 2^31 - 1.
  * @apiParam {String} data a data payload to include with the timer when it executes
  * @apiParam {Object} callback
  * @apiParam {String} callback.transport The delivery transport to use when executing the timer

--- a/lib/server/api/validators/timer.js
+++ b/lib/server/api/validators/timer.js
@@ -20,7 +20,7 @@ module.exports = function(data = {}, cb) {
   }
 
   if (data.timeout > MAX_TIMEOUT_VALUE) {
-    const err = new TypeError(`timeout must be less than or equal to ${MAX_TIMEOUT_VALUE} milliseconds`);
+    const err = new TypeError(`timeout must be less than or equal to 2147483647 milliseconds`);
     err.statusCode = 400;
     return setImmediate(cb, err);
   }

--- a/lib/server/api/validators/timer.js
+++ b/lib/server/api/validators/timer.js
@@ -9,13 +9,22 @@ function typeOf(obj) {
   return type_exp.exec( Object.prototype.toString.call(obj) )[1];
 }
 
+const MAX_TIMEOUT_VALUE = Math.pow(2, 31) - 1;
+
 module.exports = function(data = {}, cb) {
-  if( isNaN(data.timeout) || data.timeout < 1 ) {
+  if (isNaN(data.timeout) || data.timeout < 1) {
     const err = new TypeError('timeout is required and must be a positive number');
     err.statusCode = 400;
     return setImmediate(cb, err);
   }
-  if(data.data) {
+
+  if (data.timeout > MAX_TIMEOUT_VALUE) {
+    const err = new TypeError(`timeout must be less than or equal to ${MAX_TIMEOUT_VALUE} milliseconds`);
+    err.statusCode = 400;
+    return setImmediate(cb, err);
+  }
+
+  if (data.data) {
     const type = typeOf(data.data);
     if (type !== 'String' && type !== 'Object') {
       const err = new TypeError('data is required and must be a string or object');

--- a/lib/server/api/validators/timer.js
+++ b/lib/server/api/validators/timer.js
@@ -9,7 +9,8 @@ function typeOf(obj) {
   return type_exp.exec( Object.prototype.toString.call(obj) )[1];
 }
 
-const MAX_TIMEOUT_VALUE = Math.pow(2, 31) - 1;
+// 2^32 - 1
+const MAX_TIMEOUT_VALUE = 2147483647;
 
 module.exports = function(data = {}, cb) {
   if (isNaN(data.timeout) || data.timeout < 1) {

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -123,7 +123,7 @@ class Timer extends Map {
    * @method module:skyring/lib/timer#create
    * @param {String} id A unique Id of the time
    * @param {Object} body Configuration options for the timer instance
-   * @param {Number} body.timeout Duration in milisecods to delay execution of the timer
+   * @param {Number} body.timeout the time in milliseconds from now the timer should execute. This must be in the range: 0 < timeout < 2^31 - 1.
    * @param {String} body.data The data to be assicated with the timer, when it is executed
    * @param {Number} [body.created=Date.now()] timestamp when the timer is created. if not set, will default to now
    * @param {Object} callback Options for the outbound transport for the timer when it executes

--- a/test/integration/post-timer.spec.js
+++ b/test/integration/post-timer.spec.js
@@ -114,6 +114,24 @@ test('skyring:api', (t) => {
         });
     });
 
+    tt.test('should not allow request with timeout exceeding maximum - (400)', (ttt) => {
+      request
+        .post('/timer')
+        .send({
+          timeout: Math.pow(2, 31)
+        , callback: {
+            uri: `http://${hostname}:8989`
+          , method: 'post'
+          , transport: 'http'
+          }
+        })
+        .expect(400)
+        .end((err, res) => {
+          ttt.equal(typeof res.headers['x-skyring-reason'], 'string');
+          ttt.end()
+        });
+    });
+
     tt.test('should allow request with no callback uri - (400)', (ttt) => {
       request
         .post('/timer')


### PR DESCRIPTION
### Description
These commits update the API validator to check for an upper bound on the `timeout` field in the request (maximum of `2**31 - 1` or `2147483647`, [as per the NodeJS docs](https://nodejs.org/docs/latest-v6.x/api/timers.html#timers_settimeout_callback_delay_args)), as well as the README.md to call this out specifically. Please let me know if I need to update the documentation elsewhere.

### Tests
I've added an integration test to verify the API sends back a `400 Bad Request` response when the `timeout` field in the request exceeds the threshold above. All other tests pass when running the following locally:
```bash
NODE_ENV=test TEST_HOST=localhost npm test
```

Fixes: #18 