### PR TITLE
timer: Update data to use created time rather than now 

### DIFF
--- a/lib/timer.js
+++ b/lib/timer.js
@@ -191,7 +191,7 @@ timers.create(id, options, (err) => {
     }
 
     const data = {
-      created: Date.now()
+      created: created
     , id: id
     , payload: payload
     , timer: null


### PR DESCRIPTION
A huge problem with using Date.now() appears when using multiple servers. If a timer was going for 24 hours, and then the node died at the twelfth hour it will be rebalanced to a new node and will be using the created date as if it was made on the twelfth hour, thus throwing off timers.