### PR TITLE
ci: run code coverage reporter only if env var is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,21 @@ sudo: required
 services:
   - docker
 
-script: npm test
 language: node_js
+script: npm test
+after_script:
+  - if [ -n "${CODECLIMATE_REPO_TOKEN}" ]; then npm run coverage; fi
 before_install:
   - docker pull nats:latest
   - docker run --name=nats -p 4222:4222 -d nats:latest
   - docker ps -a
 git:
   depth: 3
+
 node_js:
   - "6"
   - "7"
   - "8"
-addons:
-  code_climate:
-    repo_token: 248135f96061f77d2e5f78526432fd096785d2914d8f5a73a04c061000939d5d
 env:
   - NODE_ENV=test
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "tap --cov -Rtap test",
-    "posttest": "tap --coverage-report=text-lcov | ./node_modules/.bin/codeclimate-test-reporter",
+    "coverage": "tap --coverage-report=text-lcov | ./node_modules/.bin/codeclimate-test-reporter",
     "docs": "jsdoc -c jsdoc.json && apidoc -i lib/server -o docs/api",
     "start": "npm run compose:up",
     "stop": "npm run compose:down",


### PR DESCRIPTION
the add directive doesn't seem to be effective, and the secret env vars
are not exposed on branches that are not created by the project owner.

This should allow PR checks to pass if the tests pass when a pr is not made by me.

Semver: patch