### PR TITLE
timer: be sure to flush the nats connection before closing

### DIFF
--- a/lib/timer.js
+++ b/lib/timer.js
@@ -424,7 +424,10 @@ timers.success('2e2f6dad-9678-4caf-bc41-8e62ca07d551', error)
         node: this[kNode]
       , type: EVENT_STATUS.SHUTDOWN
       }), noop)
-      setImmediate(this.nats.quit, cb)
+      this.nats.flush((err) => {
+        if (err) return cb(err);
+        this.nats.quit(cb);
+      });
     });
   }
 
@@ -444,7 +447,10 @@ timers.success('2e2f6dad-9678-4caf-bc41-8e62ca07d551', error)
           node: this[kNode]
         , type: EVENT_STATUS.SHUTDOWN
         }), noop)
-        this.nats.quit(cb);
+        this.nats.flush((err) => {
+          if (err) return cb(err);
+          this.nats.quit(cb);
+        });
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "test": "npm run check && tap --cov -Rclassic test",
+    "tap": "tap",
     "coverage": "tap --coverage-report=text-lcov | ./node_modules/.bin/codeclimate-test-reporter",
     "docs": "jsdoc -c jsdoc.json && apidoc -i lib/server -o docs/api",
     "check": "check-pkg -d !docs -d !node_modules -d !examples",
@@ -56,5 +57,11 @@
     "jsdoc": "^3.5.5",
     "supertest": "^3.1.0",
     "tap": "^12.0.1"
-  }
+  },
+  "contributors": [
+    {
+      "name": "Ian Skebba",
+      "email": "iaskebba@ucdavis.edu"
+    }
+  ]
 }


### PR DESCRIPTION
Corrects the nats client disconnect order of events. The timer instance
would close the nats connection with out waiting for the current
requests to complete resulting in timers being lost in rebalance
operations.

Always flush the nats connection before disconnecting

Fixes: #24 
Semver: patch