### PR TITLE
transports: replaces request with phin (#51)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - mkdir -p coverage
 script: npm run test:coverage
 after_script:
-  - npm run nyc report --reporter=text-lcov > coverage/lcov.info
+  - npm run nyc report -- --reporter=text-lcov > coverage/lcov.info
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
   - docker-compose -f compose/nats.yml down
 install:

--- a/packages/skyring/package-lock.json
+++ b/packages/skyring/package-lock.json
@@ -578,6 +578,11 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "centra": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/centra/-/centra-2.4.0.tgz",
+      "integrity": "sha512-AWmF3EHNe/noJHviynZOrdnUuQzT5AMgl9nJPXGvnzGXrI2ZvNDrEcdqskc4EtQwt2Q1IggXb0OXy7zZ1Xvvew=="
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -2827,7 +2832,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -2950,6 +2955,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "phin": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/phin/-/phin-3.4.1.tgz",
+      "integrity": "sha512-NkBCNRPxeyrgaPlWx4DHTAdca3s2LkvIBiiG6RoSbykcOtW/pA/7rUP/67FPIinvbo7h+HENST/vJ17LdRNUdw==",
+      "requires": {
+        "centra": "^2.2.1"
+      }
     },
     "picomatch": {
       "version": "2.2.2",
@@ -4995,7 +5008,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {

--- a/packages/skyring/package.json
+++ b/packages/skyring/package.json
@@ -44,7 +44,6 @@
     "nats": "^1.4.8",
     "path-to-regexp": "^3.0.0",
     "phin": "^3.4.1",
-    "request": "^2.88.0",
     "seeli": "^9.0.0",
     "tchannel": "^4.0.0",
     "uuid": "^3.2.1"

--- a/packages/skyring/package.json
+++ b/packages/skyring/package.json
@@ -43,6 +43,7 @@
     "memdown": "^4.0.0",
     "nats": "^1.4.8",
     "path-to-regexp": "^3.0.0",
+    "phin": "^3.4.1",
     "request": "^2.88.0",
     "seeli": "^9.0.0",
     "tchannel": "^4.0.0",

--- a/packages/skyring/test/main.spec.js
+++ b/packages/skyring/test/main.spec.js
@@ -19,7 +19,6 @@ test('server starts when executed directly', (t) => {
 
   let buf = ''
   const cases = { listen: false }
-
   child.once('error', t.threw)
   child.stderr.on('data', (chunk) => {
     buf += chunk.toString()
@@ -42,7 +41,6 @@ test('server starts when executed directly', (t) => {
   }
 
   child.on('close', (code, signal) => {
-    console.log('close', code)
     t.equal(code, 0)
     t.end()
   })

--- a/packages/skyring/test/unit/transport.http.spec.js
+++ b/packages/skyring/test/unit/transport.http.spec.js
@@ -47,9 +47,10 @@ test('http transport', async (t) => {
     const addr = `http://localhost:${state.server.address().port}/r1`
     const mock_store = {
       success: () => {
-        tt.pass('timer success')}
+        tt.pass('timer success')
+      }
     , failure: () => {
-        tt.fail('timer fail')
+        tt.fail('timer failure')
       }
     }
 

--- a/packages/skyring/test/unit/validator.spec.js
+++ b/packages/skyring/test/unit/validator.spec.js
@@ -46,10 +46,8 @@ test('timer payload validation', async (t) => {
       timeout: MAX + 1
     }, (err) => {
       tt.type(err, Error, 'error is of type Error')
-      tt.match(err, {
-        statusCode: 400
-      , message: new RegExp(`less than or equal to ${MAX}`, 'ig')
-      })
+      tt.match(err.statusCode, 400, 'error statusCode')
+      tt.match(err.message, new RegExp(`less than or equal to ${MAX}`, 'ig'), 'error message')
       tt.end()
     })
   })
@@ -63,10 +61,8 @@ test('timer payload validation', async (t) => {
     , data: false
     }, (err) => {
       tt.type(err, Error, 'error is of type Error')
-      tt.match(err, {
-        statusCode: 400
-      , message: /must be a string or object/ig
-      })
+      tt.match(err.statusCode, 400, 'error statusCode')
+      tt.match(err.message, /must be a string or object/ig, 'error message')
       tt.end()
     })
   })


### PR DESCRIPTION
The request packages was deprecated. this replaces it with the phin
package in the http transport

Semver: minor
Ref: #51